### PR TITLE
Address Islandora-1756 Add deferDerivatives to rels-ext.rdf.

### DIFF
--- a/relsext.rdf
+++ b/relsext.rdf
@@ -168,4 +168,11 @@
   <rdf:Property rdf:about="http://islandora.ca/ontology/relsext#isSequenceNumberOf$escaped_pid">
     <rdfs:label xml:lang="en">is sequence number of escaped PID</rdfs:label>
   </rdf:Property>
+
+  <!-- http://islandora.ca/ontology/relsext#deferDerivatives -->
+  <rdf:Property rdf:about="http://islandora.ca/ontology/relsext#deferDerivatives">
+    <rdfs:label xml:lang="en">defer derivatives</rdfs:label>
+    <rdfs:range rdf:resource="&xsd;boolean"/>
+  </rdf:Property>
+
 </rdf:RDF>

--- a/relsext.rdf
+++ b/relsext.rdf
@@ -172,7 +172,7 @@
   <!-- http://islandora.ca/ontology/relsext#deferDerivatives -->
   <rdf:Property rdf:about="http://islandora.ca/ontology/relsext#deferDerivatives">
     <rdfs:label xml:lang="en">defer derivatives</rdfs:label>
-    <rdfs:comment xml:lang="en">Boolean value of defer derivatives option.</rdfs:comment>
+    <rdfs:comment xml:lang="en">Prevent derivatives from running during ingest</rdfs:comment>
     <rdfs:range rdf:resource="&xsd;boolean"/>
   </rdf:Property>
 

--- a/relsext.rdf
+++ b/relsext.rdf
@@ -172,6 +172,7 @@
   <!-- http://islandora.ca/ontology/relsext#deferDerivatives -->
   <rdf:Property rdf:about="http://islandora.ca/ontology/relsext#deferDerivatives">
     <rdfs:label xml:lang="en">defer derivatives</rdfs:label>
+    <rdfs:comment xml:lang="en">Boolean value of defer derivatives option.</rdfs:comment>
     <rdfs:range rdf:resource="&xsd;boolean"/>
   </rdf:Property>
 


### PR DESCRIPTION
**JIRA Ticket**: [Islandora-1756](https://jira.duraspace.org/browse/ISLANDORA-1756)
- [IRC discussion on 7/8](http://irclogs.islandora.ca/2016-07-08.html)
- [According to Nick, anything in RELS EXT comes over as RDF Properties with migration utils](https://groups.google.com/forum/#!searchin/islandora/embargo%7Csort:date/islandora/mNMijiiscXY/PXUzMdN6AQAJ)
- [Where defer derivatives is defined](https://github.com/Islandora/islandora/blob/b5b173b32dd4ef840899bef4d773a2a4367ea06f/includes/derivatives.inc#L7-L8)
# What does this Pull Request do?

This PR adds the deferDerivatives predicate that can appear in RELS-EXT RDF.
# What's new?

While defer derivatives is added, it doesn't have a rdfs:comment that some other predicates have.
# How should this be tested?

Use the mvn xml:transform build and look for the build success / files in target directory.
# Additional Notes:

I should be honest and say I found this missing predicate by accident.  I thought we had something screwed up in our RELS-EXT.  When looking at some other users' RELS-EXT datastreams I noticed the predicated.  I was curious because I'd never seen it before so I looked it up in the ontology only to find it missing. 

I remembered a recent thread on the Google Group where Nick said, "Migration-wise now -- using migration-utils -- anything anything in the RELS-EXT or RELS-INT comes over as RDF properties on the resource." For that reason, I went ahead and submitted a jira ticket and am sending over a pull request.

It might be good to have someone who understands better why this is defined to add a rdfs:comment.
# Interested parties

@ruebot @DiegoPino
